### PR TITLE
Add separate commands for local and remote database initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,23 @@ database_id = "TU-DATABASE-ID-AQUI"  # ← Reemplaza esto
 
 ### 5. Inicializar la Base de Datos
 
+#### Para Desarrollo Local
+
 ```bash
 npm run db:init
 ```
 
-Esto creará las tablas necesarias y agregará 3 síntomas de ejemplo.
+Esto creará las tablas necesarias y agregará 3 síntomas de ejemplo en tu base de datos local.
+
+#### Para Producción
+
+Una vez que hayas desplegado el worker, inicializa la base de datos remota:
+
+```bash
+npm run db:init:remote
+```
+
+Este comando ejecutará el schema en la base de datos D1 de Cloudflare en producción.
 
 ### 6. Configurar Credenciales de Admin
 
@@ -119,11 +131,30 @@ La aplicación estará disponible en: `http://localhost:8787`
 
 ## 🚢 Desplegar a Producción
 
+### 1. Desplegar el Worker
+
 ```bash
 npm run deploy
 ```
 
 Wrangler te mostrará la URL donde tu aplicación está desplegada (ej: `https://trackme.tu-usuario.workers.dev`)
+
+### 2. Inicializar la Base de Datos en Producción
+
+Después del primer despliegue, inicializa la base de datos remota:
+
+```bash
+npm run db:init:remote
+```
+
+### 3. Configurar Secretos (si no lo hiciste antes)
+
+```bash
+wrangler secret put USER
+wrangler secret put PASSWORD
+```
+
+¡Listo! Tu aplicación está en producción.
 
 ## 📖 Uso de la Aplicación
 
@@ -169,10 +200,29 @@ Wrangler te mostrará la URL donde tu aplicación está desplegada (ej: `https:/
 
 ## 🔧 Comandos Disponibles
 
+### Desarrollo y Despliegue
 ```bash
 npm run dev       # Desarrollo local
 npm run deploy    # Desplegar a producción
-npm run db:init   # Inicializar base de datos
+```
+
+### Base de Datos
+```bash
+# Inicializar schema
+npm run db:init          # Inicializar DB local (desarrollo)
+npm run db:init:remote   # Inicializar DB remota (producción)
+
+# Ejecutar consultas SQL
+npm run db:query "SELECT * FROM symptoms"         # Consulta local
+npm run db:query:remote "SELECT * FROM symptoms"  # Consulta en producción
+```
+
+### Comandos Wrangler Directos
+```bash
+wrangler d1 execute trackme-db --local --command="..."    # Consulta local
+wrangler d1 execute trackme-db --remote --command="..."   # Consulta remota
+wrangler tail                                             # Ver logs en producción
+wrangler secret list                                      # Listar secretos
 ```
 
 ## 📊 Endpoints de la API

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "db:init": "wrangler d1 execute trackme-db --file=./schema.sql"
+    "db:init": "wrangler d1 execute trackme-db --local --file=./schema.sql",
+    "db:init:remote": "wrangler d1 execute trackme-db --remote --file=./schema.sql",
+    "db:query": "wrangler d1 execute trackme-db --local --command",
+    "db:query:remote": "wrangler d1 execute trackme-db --remote --command"
   },
   "keywords": ["cloudflare", "workers", "d1", "symptom-tracker"],
   "author": "",


### PR DESCRIPTION
- Add db:init for local development (--local flag)
- Add db:init:remote for production (--remote flag)
- Add db:query and db:query:remote for running SQL queries
- Update README with clear instructions for both environments
- Document complete production deployment workflow
- Include database initialization step in deployment section

This makes it clear when working with local vs production databases.